### PR TITLE
chore: creatorIFOLock default is already false

### DIFF
--- a/src/contracts/IFOSettings.sol
+++ b/src/contracts/IFOSettings.sol
@@ -25,11 +25,10 @@ contract IFOSettings is OwnableUpgradeable, IIFOSettings {
 
     error ZeroAddressDisallowed();
     error GovFeeTooHigh();
-    
+
     function initialize() external initializer {
         __Ownable_init();
 
-        creatorIFOLock = false;
         minimumDuration = 86400; // 1 day;
         feeReceiver = payable(msg.sender);
         maximumDuration = 7776000; // 90 days;


### PR DESCRIPTION
@0xluckyg I am wondering why `creatorIFOLock` has to be set to `false` as it is the default value? Is it for readability or? Feel free to close this if you are doing this on purpose.