### PR TITLE
fix: enum convention

### DIFF
--- a/src/contracts/IFO.sol
+++ b/src/contracts/IFO.sol
@@ -13,10 +13,10 @@ contract IFO is Initializable {
     }
 
     enum FNFTState {
-        inactive,
-        live,
-        ended,
-        redeemed
+        Inactive,
+        Live,
+        Ended,
+        Redeemed
     }
 
     IERC20 public FNFT; // fNFT the ifo contract sells
@@ -292,7 +292,7 @@ contract IFO is Initializable {
     /// @notice withdraws FNFT from sale only after IFO. Can only withdraw after NFT redemption if IFOLock enabled
     function adminWithdrawFNFT() external checkDeadline onlyCurator {
         if (!ended) revert SaleActive();
-        if (_fnftLocked() && IFNFT(address(FNFT)).auctionState() != uint256(FNFTState.ended)) {
+        if (_fnftLocked() && IFNFT(address(FNFT)).auctionState() != uint256(FNFTState.Ended)) {
             revert FNFTLocked();
         }
 

--- a/src/contracts/interfaces/IFNFT.sol
+++ b/src/contracts/interfaces/IFNFT.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.0;
 
 interface IFNFT {
     enum State {
-        inactive,
-        live,
-        ended,
-        redeemed
+        Inactive,
+        Live,
+        Ended,
+        Redeemed
     }
-    
+
     function balanceOf(address _account) external returns (uint256);
 
     function totalSupply() external returns (uint256);

--- a/src/test/FNFT.t.sol
+++ b/src/test/FNFT.t.sol
@@ -347,7 +347,7 @@ contract FNFTTest is DSTest, ERC721Holder, SetupEnvironment {
 
         user1.call_start(1.05 ether);
 
-        assertTrue(fnft.auctionState() == FNFT.State.live);
+        assertTrue(fnft.auctionState() == FNFT.State.Live);
 
         uint256 bal = address(user1).balance;
         user2.call_bid(1.5 ether);
@@ -383,13 +383,13 @@ contract FNFTTest is DSTest, ERC721Holder, SetupEnvironment {
         wethBal = address(user3).balance;
         assertEq(user3Bal + 998850637622471404, wethBal);
 
-        assertTrue(fnft.auctionState() == FNFT.State.ended);
+        assertTrue(fnft.auctionState() == FNFT.State.Ended);
     }
 
     function testRedeem() public {
         fnft.redeem();
 
-        assertTrue(fnft.auctionState() == FNFT.State.redeemed);
+        assertTrue(fnft.auctionState() == FNFT.State.Redeemed);
 
         assertEq(token.balanceOf(address(this)), 1);
     }
@@ -404,7 +404,7 @@ contract FNFTTest is DSTest, ERC721Holder, SetupEnvironment {
 
         user4.call_start(1.05 ether);
         user4.setCanReceive(false);
-        assertTrue(fnft.auctionState() == FNFT.State.live);
+        assertTrue(fnft.auctionState() == FNFT.State.Live);
         user2.call_bid(1.5 ether);
 
         assertTrue(address(user4).balance != 1.05 ether);
@@ -446,7 +446,7 @@ contract FNFTTest is DSTest, ERC721Holder, SetupEnvironment {
 
         user1.call_start(1.05 ether);
 
-        assertTrue(fnft.auctionState() == FNFT.State.live);
+        assertTrue(fnft.auctionState() == FNFT.State.Live);
 
         uint256 bal = address(user1).balance;
         user2.call_bid(1.5 ether);
@@ -482,7 +482,7 @@ contract FNFTTest is DSTest, ERC721Holder, SetupEnvironment {
         wethBal = address(user3).balance;
         assertEq(user3Bal + 1 ether, wethBal);
 
-        assertTrue(fnft.auctionState() == FNFT.State.ended);
+        assertTrue(fnft.auctionState() == FNFT.State.Ended);
     }
 
     function testGetQuorum() public {

--- a/src/test/IFO.t.sol
+++ b/src/test/IFO.t.sol
@@ -1145,11 +1145,11 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         //start and end the bidding process
         user1.call_start(10 ether);
-        assertTrue(fractionalizedNFT.auctionState() == FNFT.State.live);
+        assertTrue(fractionalizedNFT.auctionState() == FNFT.State.Live);
         vm.warp(block.timestamp + 7 days);
 
         fractionalizedNFT.end();
-        assertTrue(fractionalizedNFT.auctionState() == FNFT.State.ended);
+        assertTrue(fractionalizedNFT.auctionState() == FNFT.State.Ended);
 
         fNFTIfo.adminWithdrawFNFT();
 


### PR DESCRIPTION
https://docs.soliditylang.org/en/v0.8.13/style-guide.html#enums

Enums should be named using the CapWords style.