### PR TITLE
perf: events do not require block number as arg

### DIFF
--- a/src/contracts/IFO.sol
+++ b/src/contracts/IFO.sol
@@ -43,9 +43,9 @@ contract IFO is Initializable {
     mapping(address => bool) public whitelisted; // True if user is whitelisted
 
     event Deposit(address indexed buyer, uint256 amount, uint256 payout);
-    event Start(uint256 block);
-    event End(uint256 block);
-    event Pause(bool paused, uint256 block);
+    event Start();
+    event End();
+    event Pause(bool paused);
     event AdminProfitWithdrawal(address FNFT, uint256 amount);
     event AdminFNFTWithdrawal(address FNFT, uint256 amount);
 
@@ -191,7 +191,7 @@ contract IFO is Initializable {
         startBlock = block.number;
 
         started = true;
-        emit Start(block.number);
+        emit Start();
     }
 
     //TODO: Add a circute breaker controlled by the DAO
@@ -208,7 +208,7 @@ contract IFO is Initializable {
             pauseBlock = block.number;
             paused = true;
         }
-        emit Pause(paused, block.number);
+        emit Pause(paused);
         return paused;
     }
 
@@ -223,7 +223,7 @@ contract IFO is Initializable {
 
         ended = true;
         lockedSupply = fnft.balanceOf(address(this));
-        emit End(block.number);
+        emit End();
     }
 
     ///@notice it deposits ETH for the sale


### PR DESCRIPTION
@0xluckyg I believe it is not necessary to include the block number as an argument because when you call `eth_getLogs` or when you subscribe to the events, one of the field in the returned data object is the block number.

```
testDeposit() (gas: -307 (-0.000%))
testFail_depositMoreThanCapAfterMeetingDeposit() (gas: -307 (-0.000%))
testFail_withdrawFNFTWhileSaleActive() (gas: -307 (-0.000%))
testGetUserRemainingAllocation() (gas: -307 (-0.000%))
testFail_depositMoreThanCapAfterDeposit() (gas: -307 (-0.000%))
testFail_withdrawProfitBeforeEnd() (gas: -307 (-0.000%))
testDepositAfterWhitelisted() (gas: -307 (-0.000%))
testBuyItNow() (gas: -11625 (-0.000%))
testFail_endNotCurator() (gas: -307 (-0.001%))
testFail_endBeforDuration() (gas: -307 (-0.001%))
testFail_togglePauseNotCurator() (gas: -307 (-0.001%))
testFail_depositMoreThanCap() (gas: -307 (-0.001%))
testFail_startAlreadyStarted() (gas: -307 (-0.001%))
testFail_depositIfNotWhitelisted() (gas: -307 (-0.001%))
testFail_endBeforeMinimumDurationForInfiniteDuration() (gas: -307 (-0.001%))
testStart() (gas: -307 (-0.001%))
testWithdrawFNFTIfLockedAndRedeemed() (gas: -601 (-0.001%))
testGetQuorumOnIFOLock() (gas: -601 (-0.001%))
testWithdrawProfit() (gas: -601 (-0.001%))
testFail_WithdrawFNFTIfLockedAndNotRedeemed() (gas: -601 (-0.001%))
testFail_withdrawProfitTwice() (gas: -601 (-0.001%))
testFail_withdrawProfitNotCurator() (gas: -601 (-0.001%))
testWithdrawFNFT() (gas: -601 (-0.001%))
testWithdrawFNFTAutoEndsAfterDuration() (gas: -601 (-0.001%))
testWithdrawProfitAutoEndsAfterDuration() (gas: -601 (-0.001%))
testFail_endWhilePaused() (gas: -580 (-0.001%))
testFail_depositWhilePaused() (gas: -580 (-0.001%))
testFail_startAlreadyEnded() (gas: -601 (-0.001%))
testFail_endAfterEnd() (gas: -601 (-0.001%))
testFail_depositAfterSaleEnded() (gas: -601 (-0.001%))
testFail_togglePauseAfterEnded() (gas: -601 (-0.001%))
testFail_depositSaleEndAutoAfterDeadline() (gas: -601 (-0.001%))
testEnd() (gas: -601 (-0.001%))
testEndAfterMinimumDurationForInfiniteDuration() (gas: -601 (-0.001%))
testTogglePause() (gas: -853 (-0.001%))
testDepositAfterSaleResumesAfterDeadline() (gas: -1147 (-0.001%))
testFail_startDoesNotHaveFNFT() (gas: -5815 (-0.003%))
Overall gas change: -34821 (-0.028%)
```