### PR TITLE
perf: array unchecked increment

### DIFF
--- a/src/contracts/IFO.sol
+++ b/src/contracts/IFO.sol
@@ -171,8 +171,11 @@ contract IFO is Initializable {
      */
     function addMultipleWhitelists(address[] calldata _addresses) external onlyCurator whitelistingAllowed {
         if (_addresses.length > 333) revert TooManyWhitelists();
-        for (uint256 i = 0; i < _addresses.length; i++) {
+        for (uint256 i; i < _addresses.length;) {
             whitelisted[_addresses[i]] = true;
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/src/contracts/proxy/MultiProxyController.sol
+++ b/src/contracts/proxy/MultiProxyController.sol
@@ -27,10 +27,13 @@ contract MultiProxyController is Ownable {
         deployer = _deployer;
         uint256 length = _proxies.length;
         require(_keys.length == length, "Not equal length");
-        for (uint256 i; i < length; i++) {
+        for (uint256 i; i < length;) {
             addProxy(_keys[i], _proxies[i]);
-        } 
-    }    
+            unchecked {
+                ++i;
+            }
+        }
+    }
 
     // Proxy Gov
 
@@ -125,18 +128,24 @@ contract MultiProxyController is Ownable {
 
     function changeAllAdmins(address newAdmin) public onlyOwner {
         uint256 length = proxyKeys.length;
-        for (uint256 i; i < length; ++i) {
+        for (uint256 i; i < length;) {
             changeProxyAdmin(proxyKeys[i], newAdmin);
+            unchecked {
+                ++i;
+            }
         }
     }
 
     function getAllProxiesInfo() public view returns (string[] memory) {
         uint256 length = proxyKeys.length;
         string[] memory proxyInfos = new string[](length);
-        for (uint256 i; i < length; ++i) {
+        for (uint256 i; i < length;) {
             string memory key = proxyKeys[i];
             Proxy memory _proxy = proxyMap[key];
             proxyInfos[i] = string(abi.encodePacked(key, ": ", _proxy.name));
+            unchecked {
+                ++i;
+            }
         }
         return proxyInfos;
     }
@@ -144,17 +153,23 @@ contract MultiProxyController is Ownable {
     function getAllProxies() public view returns (address[] memory) {
         uint256 length = proxyKeys.length;
         address[] memory proxyInfos = new address[](length);
-        for (uint256 i; i < length; ++i) {
+        for (uint256 i; i < length;) {
             proxyInfos[i] = address(proxyMap[proxyKeys[i]].proxy);
+            unchecked {
+                ++i;
+            }
         }
         return proxyInfos;
     }
-    
+
     function getAllImpls() public view returns (address[] memory) {
         uint256 length = proxyKeys.length;
         address[] memory proxyInfos = new address[](length);
-        for (uint256 i; i < length; ++i) {
+        for (uint256 i; i < length;) {
             proxyInfos[i] = address(proxyMap[proxyKeys[i]].proxy.implementation());
+            unchecked {
+                ++i;
+            }
         }
         return proxyInfos;
     }


### PR DESCRIPTION
@0xluckyg

Overall gas change in tests: -34501 (-0.005%)

- In `addMultipleWhitelists`, made `uint256 i = 0` `uint256 i` even though there is no gas savings, to be consistent with another contract
- I am also using the `unchecked` trick for the view functions, even though they are view functions (might not know when one day state changing calls will use them?)