### PR TITLE
perf: cache WETH

### DIFF
--- a/src/contracts/FNFT.sol
+++ b/src/contracts/FNFT.sol
@@ -386,13 +386,12 @@ contract FNFT is ERC20Upgradeable, ERC721HolderUpgradeable {
         uint256 _reservePrice = reservePrice();
 
         if (address(priceOracle) != address(0)) {
-            IUniswapV2Pair pair = IUniswapV2Pair(
-                IPriceOracle(priceOracle).getPairAddress(address(this), IFNFTSettings(settings).WETH())
-            );
+            address weth = IFNFTSettings(settings).WETH();
+            IUniswapV2Pair pair = IUniswapV2Pair(IPriceOracle(priceOracle).getPairAddress(address(this), weth));
             uint256 reserve1;
             uint256 twapPrice;
             if (IPriceOracle(priceOracle).getPairInfo(address(pair)).exists) {
-                (, reserve1) = UniswapV2Library.getReserves(pair.factory(), address(this), IFNFTSettings(settings).WETH());
+                (, reserve1) = UniswapV2Library.getReserves(pair.factory(), address(this), weth);
                 twapPrice = _getTWAP();
             }
 
@@ -573,8 +572,9 @@ contract FNFT is ERC20Upgradeable, ERC721HolderUpgradeable {
             // If the transfer fails, wrap and send as WETH, so that
             // the auction is not impeded and the recipient still
             // can claim ETH via the WETH contract (similar to escrow).
-            IWETH(IFNFTSettings(settings).WETH()).deposit{value: value}();
-            IWETH(IFNFTSettings(settings).WETH()).transfer(to, value);
+            IWETH weth = IWETH(IFNFTSettings(settings).WETH());
+            weth.deposit{value: value}();
+            weth.transfer(to, value);
             // At this point, the recipient can unwrap WETH.
         }
     }


### PR DESCRIPTION
```
testPause() (gas: -1 (-0.000%))
testFail_listPriceZeroNoAuction() (gas: -1 (-0.000%))
testListPriceZero() (gas: -1 (-0.000%))
testFail_startAlreadyEnded() (gas: 2 (0.000%))
testFail_endAfterEnd() (gas: 2 (0.000%))
testFail_depositAfterSaleEnded() (gas: 2 (0.000%))
testFail_endWhilePaused() (gas: 2 (0.000%))
testFail_togglePauseAfterEnded() (gas: 2 (0.000%))
testFail_depositSaleEndAutoAfterDeadline() (gas: 2 (0.000%))
testFail_depositWhilePaused() (gas: 2 (0.000%))
testTogglePause() (gas: 2 (0.000%))
testAddMultipleWhitelist() (gas: 2 (0.000%))
testFail_endNotCurator() (gas: 2 (0.000%))
testFail_endBeforDuration() (gas: 2 (0.000%))
testFail_togglePauseNotCurator() (gas: 2 (0.000%))
testFail_depositMoreThanCap() (gas: 2 (0.000%))
testEnd() (gas: 2 (0.000%))
testFail_startAlreadyStarted() (gas: 2 (0.000%))
testFail_depositIfNotWhitelisted() (gas: 2 (0.000%))
testFail_removeWhitelistNotCurator() (gas: 2 (0.000%))
testFail_addMultipleWhitelistNotCurator() (gas: 2 (0.000%))
testEndAfterMinimumDurationForInfiniteDuration() (gas: 2 (0.000%))
testFail_approveUtilityContractZeroAddress() (gas: 2 (0.000%))
testFail_startNotCurator() (gas: 2 (0.000%))
testFail_addMultipleWhitelistWhitelistNotAllowed() (gas: 2 (0.000%))
testFail_addWhitelistNotCurator() (gas: 2 (0.000%))
testFail_endBeforeMinimumDurationForInfiniteDuration() (gas: 2 (0.000%))
testFail_depositBeforeSaleStarted() (gas: 2 (0.000%))
testFail_updateFNFTAddresZeroAddress() (gas: 2 (0.000%))
testFail_togglePauseWhenNotStarted() (gas: 2 (0.000%))
testFail_endBeforeStart() (gas: 2 (0.000%))
testFail_addWhitelistWhitelistNotAllowed() (gas: 2 (0.000%))
testStart() (gas: 2 (0.000%))
testFail_manualApproveUtilityContractZeroAddress() (gas: 2 (0.000%))
testAddWhitelist() (gas: 2 (0.000%))
testFail_WithdrawFNFTIfLockedAndNotRedeemed() (gas: 3 (0.000%))
testRemoveWhitelist() (gas: 2 (0.000%))
testCreateIFO() (gas: 2 (0.000%))
testFail_withdrawProfitTwice() (gas: 3 (0.000%))
testDepositAfterSaleResumesAfterDeadline() (gas: 3 (0.000%))
testFail_withdrawProfitNotCurator() (gas: 3 (0.000%))
testFail_withdrawFNFTWhileSaleActive() (gas: 3 (0.000%))
testWithdrawProfitAutoEndsAfterDuration() (gas: 3 (0.000%))
testFail_depositMoreThanCapAfterDeposit() (gas: 3 (0.000%))
testFail_withdrawProfitBeforeEnd() (gas: 3 (0.000%))
testDepositAfterWhitelisted() (gas: 3 (0.000%))
testDeposit() (gas: 4 (0.000%))
testFail_updateUserPrice_whenNoVotingTokensAndPriceTooHigh() (gas: 1 (0.000%))
testWithdrawProfit() (gas: 4 (0.000%))
testFail_updateUserPrice_whenNoVotingTokensAndPriceTooLow() (gas: 1 (0.000%))
testFail_depositMoreThanCapAfterMeetingDeposit() (gas: 4 (0.000%))
testWithdrawFNFT() (gas: 4 (0.000%))
testWithdrawFNFTAutoEndsAfterDuration() (gas: 4 (0.000%))
testGetUserRemainingAllocation() (gas: 4 (0.000%))
testGetQuorumOnIFOLock() (gas: 6 (0.000%))
testFail_updateFNFTAddressNotGov() (gas: 4 (0.000%))
testManualApproveUtilityContract() (gas: 4 (0.000%))
testApproveUtilityContract() (gas: 4 (0.000%))
testUpdateFNFTAddress() (gas: 4 (0.000%))
testRedeem() (gas: -1 (-0.000%))
testTransfer() (gas: 1 (0.000%))
testTransferBetweenUsers() (gas: 2 (0.000%))
testFail_ChangeReserve() (gas: 2 (0.000%))
testChangeReserve() (gas: 2 (0.000%))
testFail_ChangeReserveAboveMaxReserveFactor() (gas: 3 (0.000%))
testFail_ChangeReserveBelowMinReserveFactor() (gas: 3 (0.000%))
testAuctionPrice() (gas: 6 (0.000%))
testGetQuorum() (gas: 6 (0.000%))
testWithdrawFNFTIfLockedAndRedeemed() (gas: -22 (-0.000%))
testReservePriceTransfer() (gas: 6 (0.000%))
testAuctionEndCurator0() (gas: -24 (-0.000%))
testBid() (gas: -25 (-0.000%))
testGetAuctionPrice_whenVotingBelowQuorumAndLiquidityAboveThreshold_compareTWAPAndInitialReserve() (gas: -1400 (-0.002%))
testGetAuctionPrice_whenVotingAboveQuorumAndLiquidityAboveThreshold_compareTWAPAndUserReservePrice() (gas: -1401 (-0.002%))
testGetWeth() (gas: -1391 (-0.003%))
testGetAuctionPrice_whenVotingAboveQuorumAndLiquidityBelowThreshold_returnUserReservePrice() (gas: -1401 (-0.004%))
testBuyItNow() (gas: -107597 (-0.004%))
testGetAuctionPrice_whenVotingBelowQuorumAndLiquidityBelowThreshold_returnInitialReserve() (gas: -1402 (-0.005%))
Overall gas change: -114493 (-0.019%)
```

some improvements and some minor deterioration, but overall positive