### PR TITLE
chore: reserves1 is already uint256

### DIFF
--- a/src/contracts/FNFT.sol
+++ b/src/contracts/FNFT.sol
@@ -396,7 +396,7 @@ contract FNFT is ERC20Upgradeable, ERC721HolderUpgradeable {
                 twapPrice = _getTWAP();
             }
 
-            bool aboveLiquidityThreshold = uint256(reserve1 * 2) > IFNFTSettings(settings).liquidityThreshold();            
+            bool aboveLiquidityThreshold = reserve1 * 2 > IFNFTSettings(settings).liquidityThreshold();
 
             if (!aboveLiquidityThreshold && aboveQuorum){
                 //average reserve


### PR DESCRIPTION
both `reserves1` and `2` are `uint256` right?