### PR TITLE
test: use selector to test failures

### DIFF
--- a/src/test/FNFTSettings.t.sol
+++ b/src/test/FNFTSettings.t.sol
@@ -29,13 +29,13 @@ contract FNFTSettingsTest is DSTest, SetupEnvironment {
         assertEq(fnftSettings.maxAuctionLength(), 4 weeks);
     }
 
-    // too high
-    function testFail_setMaxAuction() public {
+    function testSetMaxAuctionLengthTooHigh() public {
+        vm.expectRevert(FNFTSettings.MaxAuctionLengthTooHigh.selector);
         fnftSettings.setMaxAuctionLength(10 weeks);
     }
 
-    // lower than min auction length
-    function testFail_setMaxAuction2() public {
+    function testSetMaxAuctionLengthTooLow() public {
+        vm.expectRevert(FNFTSettings.MaxAuctionLengthTooLow.selector);
         fnftSettings.setMaxAuctionLength(2.9 days);
     }
 
@@ -43,13 +43,13 @@ contract FNFTSettingsTest is DSTest, SetupEnvironment {
         fnftSettings.setMinAuctionLength(1 weeks);
     }
 
-    // too low
-    function testFail_setMinAuction() public {
-        fnftSettings.setMaxAuctionLength(0.1 days);
+    function testSetMinAuctionLengthTooLow() public {
+        vm.expectRevert(FNFTSettings.MinAuctionLengthTooLow.selector);
+        fnftSettings.setMinAuctionLength(0.1 days);
     }
 
-    // higher than max auction length
-    function testFail_setMinAuction2() public {
+    function testSetMinAuctionLengthTooHigh() public {
+        vm.expectRevert(FNFTSettings.MinAuctionLengthTooHigh.selector);
         fnftSettings.setMinAuctionLength(5 weeks);
     }
 
@@ -58,7 +58,8 @@ contract FNFTSettingsTest is DSTest, SetupEnvironment {
     }
 
     // too high
-    function testFail_setGovernanceFee() public {
+    function testSetGovernanceFeeTooHigh() public {
+        vm.expectRevert(FNFTSettings.GovFeeTooHigh.selector);
         fnftSettings.setGovernanceFee(1001);
     }
 
@@ -67,12 +68,14 @@ contract FNFTSettingsTest is DSTest, SetupEnvironment {
     }
 
     // too high
-    function testFail_setMinBidIncrease2() public {
+    function testSetMinBidIncreaseTooHigh() public {
+        vm.expectRevert(FNFTSettings.MinBidIncreaseTooHigh.selector);
         fnftSettings.setMinBidIncrease(110);
     }
 
     // too low
-    function testFail_setMinBidIncrease() public {
+    function testSetMinBidIncreaseTooLow() public {
+        vm.expectRevert(FNFTSettings.MinBidIncreaseTooLow.selector);
         fnftSettings.setMinBidIncrease(5);
     }
 
@@ -80,8 +83,8 @@ contract FNFTSettingsTest is DSTest, SetupEnvironment {
         fnftSettings.setMaxReserveFactor(10000);
     }
 
-    // lower than min
-    function testFail_setMaxReserveFactor() public {
+    function testSetMaxReserveFactorTooLow() public {
+        vm.expectRevert(FNFTSettings.MaxReserveFactorTooLow.selector);
         fnftSettings.setMaxReserveFactor(200);
     }
 
@@ -89,8 +92,8 @@ contract FNFTSettingsTest is DSTest, SetupEnvironment {
         fnftSettings.setMinReserveFactor(400);
     }
 
-    // higher than max
-    function testFail_setMinReserveFactor() public {
+    function testSetMaxReserveFactorTooHigh() public {
+        vm.expectRevert(FNFTSettings.MinReserveFactorTooHigh.selector);
         fnftSettings.setMinReserveFactor(6000);
     }
 

--- a/src/test/IFO.t.sol
+++ b/src/test/IFO.t.sol
@@ -77,6 +77,48 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
     /// -------------------------------
     /// -------- INIT FUNCTIONS -------
     /// -------------------------------
+    function createValidIFO() private returns(IFO fNFTIfo) {
+        uint balance = fractionalizedNFT.balanceOf(address(this));
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        ifoFactory.create(
+            address(fractionalizedNFT), // the address of the fractionalized token
+            balance, // amountForSale
+            0.01 ether, //price per token
+            fractionalizedNFT.totalSupply(), // max amount someone can buy
+            ifoSettings.minimumDuration(), //sale duration
+            false // allow whitelist
+        );
+        fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    }
+
+    function createValidAllowWhitelistIFO() private returns(IFO fNFTIfo) {
+        uint balance = fractionalizedNFT.balanceOf(address(this));
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        ifoFactory.create(
+            address(fractionalizedNFT), // the address of the fractionalized token
+            balance, // amountForSale
+            0.01 ether, //price per token
+            fractionalizedNFT.totalSupply(), // max amount someone can buy
+            ifoSettings.minimumDuration(), //sale duration
+            true // allow whitelist
+        );
+        fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    }
+
+    function createValidIFOWith3EthCap() private returns(IFO fNFTIfo) {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 price = 0.01 ether;
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        ifoFactory.create(
+            address(fractionalizedNFT), // the address of the fractionalized token
+            balance, //amountForSale
+            price, //price per token
+            3 ether * 1e18 / price, // max amount someone can buy
+            ifoSettings.minimumDuration(), //sale duration
+            false // allow whitelist
+        );
+        fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    }
 
     function testPause() public {
         ifoFactory.pause();
@@ -84,141 +126,152 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
     }
 
     function testCreateIFO() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         assertEq(fractionalizedNFT.balanceOf(address(fNFTIfo)), fractionalizedNFT.totalSupply());
         assertEq(fNFTIfo.duration(), ifoSettings.minimumDuration());
     }
 
-    function testFail_createIFOInvalidAddress() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
+    function testCreateIFOInvalidAddress() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidAddress.selector);
         ifoFactory.create(
             address(0), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
+            balance, //amountForSale
             0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
+            totalSupply, // max amount someone can buy
+            minimumDuration, //sale duration
             false // allow whitelist
         );
     }
 
-    function testFail_createIFOMarketCapTooHigh() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        //burn 1
-        fractionalizedNFT.transferFrom(address(this), address(0), 1);
+    function testCreateIFONotEnoughSupply() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        // burn 1
+        fractionalizedNFT.transfer(0x000000000000000000000000000000000000dEaD, 1);
+        vm.expectRevert(IFO.NotEnoughSupply.selector);
         ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
+            address(fractionalizedNFT),
+            balance, //amountForSale
             0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
+            totalSupply, // max amount someone can buy
+            minimumDuration, //sale duration
             false // allow whitelist
         );
     }
 
-    function testFail_createIFONotEnoughSupply() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        //burn 1
-        fractionalizedNFT.transferFrom(address(this), address(0), 1);
+    function testCreateIFOMarketCapTooHigh() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidCap.selector);
         ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
+            address(fractionalizedNFT),
+            balance, //amountForSale
             0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
+            totalSupply + 1, // max amount someone can buy
+            minimumDuration, //sale duration
             false // allow whitelist
         );
     }
 
-    function testFail_createIFOAmountForSaleTooLow() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
+    function testCreateIFOMarketCapTooLow() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidCap.selector);
         ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            0, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-    }
-
-    function testFail_createIFOAmountForSaleTooHigh() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this))+1, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-    }
-
-    function testFail_createIFOMarketCapHigherThanInitialReserve() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.02 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-    }
-
-    function testFail_createIFOCapTooHigh() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply() + 1, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-    }
-
-    function testFail_createIFOCapTooLow() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
+            address(fractionalizedNFT),
+            balance, //amountForSale
             0.01 ether, //price per token
             0, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
+            minimumDuration, //sale duration
             false // allow whitelist
         );
     }
 
-    function testFail_createIFODurationTooLow() public {
+    function testCreateIFOAmountForSaleTooLow() public {
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
         fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
+        vm.expectRevert(IFO.InvalidAmountForSale.selector);
         ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
+            address(fractionalizedNFT),
+            0, // amountForSale
             0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration() - 1, //sale duration
+            totalSupply, // max amount someone can buy
+            minimumDuration, //sale duration
             false // allow whitelist
         );
     }
 
-    function testFail_createIFODurationTooHigh() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
+    function testCreateIFOAmountForSaleTooHigh() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidAmountForSale.selector);
         ifoFactory.create(
-            address(fractionalizedNFT), // wrong address
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
+            address(fractionalizedNFT),
+            balance + 1, //amountForSale
             0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.maximumDuration() + 1, //sale duration
+            totalSupply, // max amount someone can buy
+            minimumDuration, //sale duration
+            false // allow whitelist
+        );
+    }
+
+    function testCreateIFOMarketCapHigherThanInitialReserve() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidReservePrice.selector);
+        ifoFactory.create(
+            address(fractionalizedNFT),
+            balance, //amountForSale
+            0.02 ether, //price per token
+            totalSupply, // max amount someone can buy
+            minimumDuration, //sale duration
+            false // allow whitelist
+        );
+    }
+
+    function testCreateIFODurationTooLow() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 minimumDuration = ifoSettings.minimumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidDuration.selector);
+        ifoFactory.create(
+            address(fractionalizedNFT),
+            balance, //amountForSale
+            0.01 ether, //price per token
+            totalSupply, // max amount someone can buy
+            minimumDuration - 1, //sale duration
+            false // allow whitelist
+        );
+    }
+
+    function testCreateIFODurationTooHigh() public {
+        uint256 balance = fractionalizedNFT.balanceOf(address(this));
+        uint256 totalSupply = fractionalizedNFT.totalSupply();
+        uint256 maximumDuration = ifoSettings.maximumDuration();
+        fractionalizedNFT.approve(address(ifoFactory), balance);
+        vm.expectRevert(IFO.InvalidDuration.selector);
+        ifoFactory.create(
+            address(fractionalizedNFT),
+            balance, //amountForSale
+            0.01 ether, //price per token
+            totalSupply, // max amount someone can buy
+            maximumDuration + 1, //sale duration
             false // allow whitelist
         );
     }
@@ -266,22 +319,14 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         assertEq(address(fNFTIfo.fnft()), address(user2));
     }
 
-    function testFail_updateFNFTAddresZeroAddress() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testUpdateFNFTAddresZeroAddress() public {
+        IFO fNFTIfo = createValidIFO();
 
+        vm.expectRevert(IFO.InvalidAddress.selector);
         fNFTIfo.updateFNFTAddress(address(0));
     }
 
-    function testFail_updateFNFTAddressNotGov() public {
+    function testUpdateFNFTAddressNotGov() public {
         fractionalizedNFT.approve(address(this), fractionalizedNFT.balanceOf(address(this)));
         fractionalizedNFT.transferFrom(address(this), address(user1), fractionalizedNFT.balanceOf(address(this)));
 
@@ -299,6 +344,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         );
         IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
 
+        vm.expectRevert(IFO.NotGov.selector);
         fNFTIfo.updateFNFTAddress(address(user1));
 
         vm.stopPrank();
@@ -309,67 +355,32 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
     /// -----------------------------------
 
     function testAddWhitelist() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidAllowWhitelistIFO();
 
         fNFTIfo.addWhitelist(address(user1));
-
-        assertEq(fNFTIfo.whitelisted(address(user1)) ? 1 : 0, true ? 1 : 0);
+        assertTrue(fNFTIfo.whitelisted(address(user1)));
     }
 
-    function testFail_addWhitelistNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testAddWhitelistNotCurator() public {
+        IFO fNFTIfo = createValidAllowWhitelistIFO();
 
         vm.startPrank(address(user1));
 
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.addWhitelist(address(user1));
 
         vm.stopPrank();
     }
 
-    function testFail_addWhitelistWhitelistNotAllowed() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testAddWhitelistWhitelistNotAllowed() public {
+        IFO fNFTIfo = createValidIFO();
 
+        vm.expectRevert(IFO.WhitelistingDisallowed.selector);
         fNFTIfo.addWhitelist(address(user1));
     }
 
     function testAddMultipleWhitelist() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidAllowWhitelistIFO();
 
         address[] memory whitelists = new address[](3);
 
@@ -378,22 +389,13 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         whitelists[2] = address(user3);
         fNFTIfo.addMultipleWhitelists(whitelists);
 
-        assertEq(fNFTIfo.whitelisted(address(user1)) ? 1 : 0, true ? 1 : 0);
-        assertEq(fNFTIfo.whitelisted(address(user2)) ? 1 : 0, true ? 1 : 0);
-        assertEq(fNFTIfo.whitelisted(address(user3)) ? 1 : 0, true ? 1 : 0);
+        assertTrue(fNFTIfo.whitelisted(address(user1)));
+        assertTrue(fNFTIfo.whitelisted(address(user2)));
+        assertTrue(fNFTIfo.whitelisted(address(user3)));
     }
 
-    function testFail_addMultipleWhitelistNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testAddMultipleWhitelistNotCurator() public {
+        IFO fNFTIfo = createValidAllowWhitelistIFO();
 
         address[] memory whitelists = new address[](3);
 
@@ -403,22 +405,14 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         vm.startPrank(address(user1));
 
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.addMultipleWhitelists(whitelists);
 
         vm.stopPrank();
     }
 
-    function testFail_addMultipleWhitelistWhitelistNotAllowed() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testAddMultipleWhitelistWhitelistNotAllowed() public {
+        IFO fNFTIfo = createValidIFO();
 
         address[] memory whitelists = new address[](3);
 
@@ -426,64 +420,39 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         whitelists[1] = address(user2);
         whitelists[2] = address(user3);
 
+        vm.expectRevert(IFO.WhitelistingDisallowed.selector);
         fNFTIfo.addMultipleWhitelists(whitelists);
     }
 
     function testRemoveWhitelist() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidAllowWhitelistIFO();
 
         fNFTIfo.addWhitelist(address(user1));
 
-        assertEq(fNFTIfo.whitelisted(address(user1)) ? 1 : 0, true ? 1 : 0);
+        assertTrue(fNFTIfo.whitelisted(address(user1)));
 
         fNFTIfo.removeWhitelist(address(user1));
 
-        assertEq(fNFTIfo.whitelisted(address(user1)) ? 1 : 0, false ? 1 : 0);
+        assertTrue(!fNFTIfo.whitelisted(address(user1)));
     }
 
-    function testFail_removeWhitelistNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testRemoveWhitelistNotCurator() public {
+        IFO fNFTIfo = createValidAllowWhitelistIFO();
 
         fNFTIfo.addWhitelist(address(user1));
 
-        assertEq(fNFTIfo.whitelisted(address(user1)) ? 1 : 0, true ? 1 : 0);
+        assertTrue(fNFTIfo.whitelisted(address(user1)));
 
         vm.startPrank(address(user1));
 
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.removeWhitelist(address(user1));
 
         vm.stopPrank();
     }
 
     function testStart() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         assertTrue(!fNFTIfo.started());
 
@@ -492,38 +461,21 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         assertTrue(fNFTIfo.started());
     }
 
-    function testFail_startNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testStartNotCurator() public {
+        IFO fNFTIfo = createValidIFO();
 
         assertTrue(!fNFTIfo.started());
 
         vm.startPrank(address(user1));
 
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.start();
 
         vm.stopPrank();
     }
 
-    function testFail_startAlreadyStarted() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testStartAlreadyStarted() public {
+        IFO fNFTIfo = createValidIFO();
 
         assertTrue(!fNFTIfo.started());
 
@@ -531,20 +483,12 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         assertTrue(fNFTIfo.started());
 
+        vm.expectRevert(IFO.SaleAlreadyStarted.selector);
         fNFTIfo.start();
     }
 
-    function testFail_startAlreadyEnded() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEnd() public {
+        IFO fNFTIfo = createValidIFO();
 
         assertTrue(!fNFTIfo.started());
 
@@ -557,8 +501,6 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.end();
 
         assertTrue(fNFTIfo.ended());
-
-        fNFTIfo.start();
     }
 
     function testFail_startDoesNotHaveFNFT() public {
@@ -580,38 +522,8 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.start();
     }
 
-    function testEnd() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
-
-        fNFTIfo.start();
-
-        assertTrue(fNFTIfo.started());
-
-        vm.roll(fNFTIfo.startBlock() + ifoSettings.minimumDuration() + 1);
-
-        fNFTIfo.end();
-    }
-
-    function testFail_endNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEndNotCurator() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -621,22 +533,14 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         vm.startPrank(address(user1));
 
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.end();
 
         vm.stopPrank();
     }
 
-    function testFail_endWhilePaused() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEndWhilePaused() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -648,37 +552,21 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         vm.roll(fNFTIfo.startBlock() + ifoSettings.minimumDuration() + 1);
 
+        vm.expectRevert(IFO.ContractPaused.selector);
         fNFTIfo.end();
     }
 
-    function testFail_endBeforeStart() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEndBeforeStart() public {
+        IFO fNFTIfo = createValidIFO();
 
         assertTrue(!fNFTIfo.started());
 
+        vm.expectRevert(IFO.SaleUnstarted.selector);
         fNFTIfo.end();
     }
 
-    function testFail_endBeforDuration() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEndBeforeDuration() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -686,21 +574,12 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         vm.roll(fNFTIfo.startBlock() + ifoSettings.minimumDuration());
 
+        vm.expectRevert(IFO.DeadlineActive.selector);
         fNFTIfo.end();
-
     }
 
-    function testFail_endAfterEnd() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEndAfterEnd() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -712,39 +591,23 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         assertTrue(fNFTIfo.ended());
 
+        vm.expectRevert(IFO.SaleAlreadyEnded.selector);
         fNFTIfo.end();
     }
 
-    function testFail_endBeforeMinimumDurationForInfiniteDuration() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            0, //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testEndBeforeMinimumDurationForInfiniteDuration() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
         assertTrue(fNFTIfo.started());
 
+        vm.expectRevert(IFO.DeadlineActive.selector);
         fNFTIfo.end();
     }
 
     function testEndAfterMinimumDurationForInfiniteDuration() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            0, //sale duration
-            true // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -756,16 +619,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
     }
 
     function testTogglePause() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -785,37 +639,20 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.togglePause();
 
-        assertEq(fNFTIfo.paused() ? 1 : 0, false ? 1 : 0);
+        assertTrue(!fNFTIfo.paused());
 
         assertEq(fNFTIfo.duration(), ifoSettings.minimumDuration() + 1000);
     }
 
-    function testFail_togglePauseWhenNotStarted() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testTogglePauseWhenNotStarted() public {
+        IFO fNFTIfo = createValidIFO();
 
+        vm.expectRevert(IFO.SaleUnstarted.selector);
         fNFTIfo.togglePause();
     }
 
-    function testFail_togglePauseAfterEnded() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testTogglePauseAfterEnded() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -823,20 +660,12 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.end();
 
+        vm.expectRevert(IFO.SaleAlreadyEnded.selector);
         fNFTIfo.togglePause();
     }
 
-    function testFail_togglePauseNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testTogglePauseNotCurator() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -844,22 +673,14 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         vm.startPrank(address(user1));
 
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.togglePause();
 
         vm.stopPrank();
     }
 
     function testWithdrawProfit() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
         uint256 originalAccountBalance = address(this).balance;
         uint256 originalUser2Balance = address(user2).balance;
 
@@ -869,7 +690,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         uint256 profit = 1 ether - fee;
 
         fNFTIfo.start();
-        
+
         assertTrue(fNFTIfo.started());
 
         fNFTIfo.deposit{value: 1 ether}();
@@ -901,17 +722,8 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         assertEq(address(this).balance, originalAccountBalance - 1 ether + profit * 2);
     }
 
-    function testFail_withdrawProfitNotCurator() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testWithdrawProfitNotCurator() public {
+        IFO fNFTIfo = createValidIFO();
 
         ifoSettings.setFeeReceiver(payable(address(user1)));
 
@@ -926,21 +738,13 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.end();
 
         vm.startPrank(address(user2));
+        vm.expectRevert(IFO.NotCurator.selector);
         fNFTIfo.adminWithdrawProfit();
         vm.stopPrank();
     }
 
     function testWithdrawProfitAutoEndsAfterDuration() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         ifoSettings.setFeeReceiver(payable(address(user1)));
 
@@ -955,7 +759,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.adminWithdrawProfit();
     }
 
-    function testFail_withdrawProfitBeforeEnd() public {
+    function testWithdrawProfitBeforeEnd() public {
         fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
         ifoFactory.create(
             address(fractionalizedNFT), // the address of the fractionalized token
@@ -977,20 +781,12 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         vm.roll(fNFTIfo.startBlock() + ifoSettings.minimumDuration() + 1);
 
+        vm.expectRevert(IFO.SaleActive.selector);
         fNFTIfo.adminWithdrawProfit();
     }
 
-    function testFail_withdrawProfitTwice() public {
-        fractionalizedNFT.approve(address(ifoFactory), fractionalizedNFT.balanceOf(address(this)));
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            fractionalizedNFT.balanceOf(address(this)), //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testWithdrawProfitTwice() public {
+        IFO fNFTIfo = createValidIFO();
 
         ifoSettings.setFeeReceiver(payable(address(user1)));
 
@@ -1004,21 +800,13 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.adminWithdrawProfit();
 
+        vm.expectRevert(IFO.NoProfit.selector);
         fNFTIfo.adminWithdrawProfit();
     }
 
     function testWithdrawFNFT() public {
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -1032,7 +820,8 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.deposit{value: 1 ether}();
         vm.stopPrank();
 
-        assertEq(fractionalizedNFT.balanceOf(address(fNFTIfo)), originalBalance - (1 ether * 1e18 / 0.01 ether));
+        uint256 withdrawnBalance = originalBalance - (1 ether * 1e18 / 0.01 ether);
+        assertEq(fractionalizedNFT.balanceOf(address(fNFTIfo)), withdrawnBalance);
 
         vm.roll(fNFTIfo.startBlock() + ifoSettings.minimumDuration() + 1);
 
@@ -1042,21 +831,12 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         assertEq(fractionalizedNFT.balanceOf(address(fNFTIfo)), 0);
 
-        assertEq(fractionalizedNFT.balanceOf(address(this)), originalBalance - (1 ether * 1e18 / 0.01 ether));
+        assertEq(fractionalizedNFT.balanceOf(address(this)), withdrawnBalance);
     }
 
-    function testFail_withdrawFNFTWhileSaleActive() public {
+    function testWithdrawFNFTWhileSaleActive() public {
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -1072,21 +852,13 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         assertEq(fractionalizedNFT.balanceOf(address(fNFTIfo)), originalBalance - (1 ether * 1e18 / 0.01 ether));
 
+        vm.expectRevert(IFO.SaleActive.selector);
         fNFTIfo.adminWithdrawFNFT();
     }
 
     function testWithdrawFNFTAutoEndsAfterDuration() public {
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
@@ -1113,16 +885,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
     function testWithdrawFNFTIfLockedAndRedeemed() public {
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
         ifoSettings.setCreatorIFOLock(true);
 
         fNFTIfo.start();
@@ -1158,18 +921,9 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         assertEq(fractionalizedNFT.balanceOf(address(this)), originalBalance - (1 ether * 1e18 / 0.01 ether));
     }
 
-    function testFail_WithdrawFNFTIfLockedAndNotRedeemed() public {
+    function testWithdrawFNFTIfLockedAndNotRedeemed() public {
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
         ifoSettings.setCreatorIFOLock(true);
         fNFTIfo.start();
 
@@ -1189,22 +943,14 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.end();
 
+        vm.expectRevert(IFO.FNFTLocked.selector);
         fNFTIfo.adminWithdrawFNFT();
     }
 
     function testApproveUtilityContract() public {
         ifoSettings.setCreatorUtilityContract(address(user2));
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         vm.startPrank(address(user2));
         fractionalizedNFT.transferFrom(address(fNFTIfo), address(user2), fractionalizedNFT.balanceOf(address(fNFTIfo)));
@@ -1215,17 +961,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
     }
 
     function testFail_approveUtilityContractZeroAddress() public {
-        uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         vm.startPrank(address(user2));
         fractionalizedNFT.transferFrom(address(fNFTIfo), address(user2), fractionalizedNFT.balanceOf(address(fNFTIfo)));
@@ -1234,16 +970,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
     function testManualApproveUtilityContract() public {
         uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFO();
 
         ifoSettings.setCreatorUtilityContract(address(user2));
 
@@ -1257,19 +984,10 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         assertEq(fractionalizedNFT.balanceOf(address(user2)), originalBalance);
     }
 
-    function testFail_manualApproveUtilityContractZeroAddress() public {
-        uint originalBalance = fractionalizedNFT.balanceOf(address(this));
-        fractionalizedNFT.approve(address(ifoFactory), originalBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalBalance, //amountForSale
-            0.01 ether, //price per token
-            fractionalizedNFT.totalSupply(), // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testManualApproveUtilityContractZeroAddress() public {
+        IFO fNFTIfo = createValidIFO();
 
+        vm.expectRevert(IFO.InvalidAddress.selector);
         fNFTIfo.approve();
     }
 
@@ -1280,16 +998,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
     function testDeposit() public {
         uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
         uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFOWith3EthCap();
         uint256 originalAccountBalance = address(this).balance;
         uint256 originalUser2Balance = address(user2).balance;
         uint256 originalUser1Balance = address(user1).balance;
@@ -1302,7 +1011,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.start();
 
         //started
-        assertEq(fNFTIfo.started() ? 1 : 0, true ? 1 : 0, "started");
+        assertTrue(fNFTIfo.started());
 
         //start remaining allocation 3
         assertEq(fNFTIfo.getUserRemainingAllocation(address(this)), 3 ether * 1e18 / price, "this remaining allocaiton 3");
@@ -1356,19 +1065,8 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         assertEq(address(user1).balance, originalUser1Balance + fee * 3);
     }
 
-    function testFail_depositAfterSaleEnded() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositAfterSaleEnded() public {
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 
@@ -1376,43 +1074,23 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.end();
 
+        vm.expectRevert(IFO.SaleAlreadyEnded.selector);
         fNFTIfo.deposit{value: 1 ether}();
     }
 
-    function testFail_depositWhilePaused() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositWhilePaused() public {
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 
         fNFTIfo.togglePause();
 
+        vm.expectRevert(IFO.ContractPaused.selector);
         fNFTIfo.deposit{value: 1 ether}();
     }
 
     function testDepositAfterSaleResumesAfterDeadline() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 
@@ -1435,45 +1113,25 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.end();
     }
 
-    function testFail_depositSaleEndAutoAfterDeadline() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositSaleEndAutoAfterDeadline() public {
+        IFO fNFTIfo = createValidIFO();
 
         fNFTIfo.start();
 
         vm.roll(fNFTIfo.startBlock() + ifoSettings.minimumDuration() + 1);
 
+        vm.expectRevert(IFO.SaleAlreadyEnded.selector);
         fNFTIfo.deposit{value: 1 ether}();
     }
 
-    function testFail_depositBeforeSaleStarted() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositBeforeSaleStarted() public {
+        IFO fNFTIfo = createValidIFO();
 
+        vm.expectRevert(IFO.SaleUnstarted.selector);
         fNFTIfo.deposit{value: 1 ether}();
     }
 
-    function testFail_depositIfNotWhitelisted() public {
+    function testDepositIfNotWhitelisted() public {
         uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
         uint256 price = 0.01 ether;
         fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
@@ -1489,6 +1147,7 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.start();
 
+        vm.expectRevert(IFO.NotWhitelisted.selector);
         fNFTIfo.deposit{value: 1 ether}();
     }
 
@@ -1512,59 +1171,28 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
         fNFTIfo.deposit{value: 1 ether}();
     }
 
-    function testFail_depositMoreThanCap() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositMoreThanCap() public {
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 
+        vm.expectRevert(IFO.OverLimit.selector);
         fNFTIfo.deposit{value: 3.1 ether}();
     }
 
-    function testFail_depositMoreThanCapAfterDeposit() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositMoreThanCapAfterDeposit() public {
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 
         fNFTIfo.deposit{value: 1 ether}();
 
+        vm.expectRevert(IFO.OverLimit.selector);
         fNFTIfo.deposit{value: 2.1 ether}();
     }
 
-    function testFail_depositMoreThanCapAfterMeetingDeposit() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
-        uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+    function testDepositMoreThanCapAfterMeetingDeposit() public {
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 
@@ -1572,22 +1200,13 @@ contract IFOTest is DSTest, ERC721Holder, SetupEnvironment {
 
         fNFTIfo.deposit{value: 2 ether}();
 
+        vm.expectRevert(IFO.OverLimit.selector);
         fNFTIfo.deposit{value: 1 ether}();
     }
 
     function testGetUserRemainingAllocation() public {
-        uint256 originalAccountFNFTBalance = fractionalizedNFT.balanceOf(address(this));
         uint256 price = 0.01 ether;
-        fractionalizedNFT.approve(address(ifoFactory), originalAccountFNFTBalance);
-        ifoFactory.create(
-            address(fractionalizedNFT), // the address of the fractionalized token
-            originalAccountFNFTBalance, //amountForSale
-            price, //price per token
-            3 ether * 1e18 / price, // max amount someone can buy
-            ifoSettings.minimumDuration(), //sale duration
-            false // allow whitelist
-        );
-        IFO fNFTIfo = IFO(ifoFactory.getIFO(address(fractionalizedNFT)));
+        IFO fNFTIfo = createValidIFOWith3EthCap();
 
         fNFTIfo.start();
 

--- a/src/test/IFOSettings.t.sol
+++ b/src/test/IFOSettings.t.sol
@@ -35,13 +35,16 @@ contract IFOSettingsTest is DSTest, SetupEnvironment {
         assertEq(ifoSettings.maximumDuration(), 86401);
     }
 
-    function testFail_invalidMinimumDuration() public {
+    function testInvalidMinimumDuration() public {
         ifoSettings.setMaximumDuration(86401);
+        vm.expectRevert(IFOSettings.InvalidDuration.selector);
         ifoSettings.setMinimumDuration(86402);
     }
 
-    function testFail_invalidMaximumDuration() public {
-        ifoSettings.setMaximumDuration(ifoSettings.minimumDuration() - 1);
+    function testInvalidMaximumDuration() public {
+        uint256 val = ifoSettings.minimumDuration() - 1;
+        vm.expectRevert(IFOSettings.InvalidDuration.selector);
+        ifoSettings.setMaximumDuration(val);
     }
 
     function test_setCreatorUtilityContract() public {
@@ -57,7 +60,8 @@ contract IFOSettingsTest is DSTest, SetupEnvironment {
         assertEq(ifoSettings.governanceFee(), 1000);
     }
 
-    function testFail_setGovernanceFee() public {
+    function testSetGovernanceFeeTooHigh() public {
+        vm.expectRevert(IFOSettings.GovFeeTooHigh.selector);
         ifoSettings.setGovernanceFee(1001);
     }
 
@@ -66,7 +70,8 @@ contract IFOSettingsTest is DSTest, SetupEnvironment {
         assertEq(ifoSettings.feeReceiver(), payable(address(1)));
     }
 
-    function testFail_setFeeReceiver() public {
+    function testSetFeeReceiverZeroAddressDisallowed() public {
+        vm.expectRevert(IFOSettings.ZeroAddressDisallowed.selector);
         ifoSettings.setFeeReceiver(payable(address(0)));
     }
 }

--- a/src/test/PriceOracle.t.sol
+++ b/src/test/PriceOracle.t.sol
@@ -12,7 +12,7 @@ import {IUniswapV2Factory} from "../contracts/interfaces/IUniswapV2Factory.sol";
 import {PairInfo} from "../contracts/interfaces/IPriceOracle.sol";
 import {WETH} from "../contracts/mocks/WETH.sol";
 import {MockERC20Upgradeable} from "../contracts/mocks/ERC20.sol";
-import {console, CheatCodes, SetupEnvironment, User, Curator, UserNoETH, Pair, PairWithWETH} from "./utils/utils.sol"; 
+import {console, CheatCodes, SetupEnvironment, User, Curator, UserNoETH, Pair, PairWithWETH} from "./utils/utils.sol";
 import "../contracts/libraries/math/FixedPoint.sol";
 import "../contracts/libraries/UQ112x112.sol";
 
@@ -20,29 +20,29 @@ import "../contracts/libraries/UQ112x112.sol";
 contract PriceOracleTest is DSTest, SetupEnvironment {
     using FixedPoint for *;
     using UQ112x112 for uint224;
-    
+
     PriceOracle public priceOracle;
     IUniswapV2Factory public pairFactory;
     Pair public pair;
     PairWithWETH public pairWithWeth;
-    
+
     function setUp() public {
         setupEnvironment(1000 ether);
         (pairFactory, priceOracle, , , , , ) = setupContracts(10 ether);
-        
+
         MockERC20Upgradeable token0 = new MockERC20Upgradeable();
         token0.initialize("Fake Token 0", "FT0");
         token0.mint(address(this), 100 ether);
 
-        MockERC20Upgradeable token1 = new MockERC20Upgradeable(); 
+        MockERC20Upgradeable token1 = new MockERC20Upgradeable();
         token1.initialize("Fake Token 1", "FT1");
         token1.mint(address(this), 100 ether);
-        
+
         pair = new Pair(address(pairFactory), address(token0), address(token1), vm);
         pair.receiveToken(50 ether, 100 ether);
-        
+
         pairWithWeth = new PairWithWETH(address(pairFactory), address(token0), address(weth), vm);
-        pairWithWeth.receiveToken(50 ether, 100 ether);        
+        pairWithWeth.receiveToken(50 ether, 100 ether);
     }
 
     /**
@@ -64,7 +64,7 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         // Get token addresses with UniswapV2Pair interface.
         address tokenA = IUniswapV2Pair(pairAddress).token0();
         address tokenB = IUniswapV2Pair(pairAddress).token1();
-        
+
         assertEq(pairInfo.token0, tokenA);
         assertEq(pairInfo.token1, tokenB);
         assertEq(pairInfo.price0CumulativeLast, 0);
@@ -86,7 +86,7 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         address token0 = address(pair.token0());
         address token1 = address(pair.token1());
         // Since pair info does not exist in price oracle, updatePairInfo would add pair info to price oracle.
-        priceOracle.updatePairInfo(token0, token1); 
+        priceOracle.updatePairInfo(token0, token1);
         (, , uint256 t0) = IUniswapV2Pair(pairAddress).getReserves();
 
         // Get the last blocktimestamp and move block.timestamp forward.
@@ -94,25 +94,25 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         vm.warp(t0 + jump);
         IUniswapV2Pair(pairAddress).sync();
 
-        // Update price oracle. 
+        // Update price oracle.
         priceOracle.updatePairInfo(token0, token1);
 
-        // VERIFY 
+        // VERIFY
         // check that price has been updated in price oracle.
         PairInfo memory pairInfo = priceOracle.getPairInfo(token0, token1);
         (uint256 reserve0, uint256 reserve1, ) = IUniswapV2Pair(pairAddress).getReserves();
-        
-        // price(0|1)CumulativeLast = 0 * t0 + token(0|1)Balance * t1        
+
+        // price(0|1)CumulativeLast = 0 * t0 + token(0|1)Balance * t1
         assertEq(pairInfo.price0CumulativeLast, uint256(UQ112x112.encode(uint112(reserve1)).uqdiv(uint112(reserve0))) * jump);
         assertEq(pairInfo.price1CumulativeLast, uint256(UQ112x112.encode(uint112(reserve0)).uqdiv(uint112(reserve1))) * jump);
 
         // price(0|1)Average = (0 * t0 + token(0|1)Balance * t1) / period
-        assertEq(pairInfo.price0Average._x, uint256(UQ112x112.encode(uint112(reserve1)).uqdiv(uint112(reserve0)))); 
+        assertEq(pairInfo.price0Average._x, uint256(UQ112x112.encode(uint112(reserve1)).uqdiv(uint112(reserve0))));
         assertEq(pairInfo.price1Average._x, uint256(UQ112x112.encode(uint112(reserve0)).uqdiv(uint112(reserve1))));
 
         assertEq(pairInfo.totalUpdates, 1);
     }
-   
+
     /**
     Test updatePairInfo when uniswap pair does not exist.
      */
@@ -122,30 +122,30 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         address token0 = address(new MockERC20Upgradeable());
         address token1 = address(new MockERC20Upgradeable());
         priceOracle.updatePairInfo(token0, token1);
-        
+
         // VERIFY
         // Check that the pair is not updated and does not exist in price oracle.
         PairInfo memory pairInfo = priceOracle.getPairInfo(token0, token1);
         assertTrue(!pairInfo.exists);
     }
-    
+
     /**
-    Test updatePairInfo when period has not elapsed. 
+    Test updatePairInfo when period has not elapsed.
      */
     function testUpdatePairInfo_periodNotElapsed() public {
         // SETUP
         address pairAddress = address(pair.uPair());
         address token0 = address(pair.token0());
         address token1 = address(pair.token1());
-        // Get cumulative last prices of the tokens before the pair as been updated. 
+        // Get cumulative last prices of the tokens before the pair as been updated.
         uint256 price0CumulativeLast = IUniswapV2Pair(pairAddress).price0CumulativeLast();
         uint256 price1CumulativeLast = IUniswapV2Pair(pairAddress).price1CumulativeLast();
-        
+
         // ACTION
         // Add pair info to price oracle.
         priceOracle.updatePairInfo(token0, token1);
 
-        // Sync pair to match reserve to token balances. 
+        // Sync pair to match reserve to token balances.
         IUniswapV2Pair(pairAddress).sync();
         (, , uint256 t0) = IUniswapV2Pair(pairAddress).getReserves();
 
@@ -154,22 +154,22 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         vm.warp(t0 + jump);
         IUniswapV2Pair(pairAddress).sync();
 
-        // Update price oracle. 
+        // Update price oracle.
         priceOracle.updatePairInfo(token0, token1);
 
-        // VERIFY 
+        // VERIFY
         // check that price has NOT been updated in price oracle.
         PairInfo memory pairInfo = priceOracle.getPairInfo(token0, token1);
-        
-        // price(0|1)CumulativeLast = 0 * t0 + token(0|1)Balance * t1        
+
+        // price(0|1)CumulativeLast = 0 * t0 + token(0|1)Balance * t1
         assertEq(pairInfo.price0CumulativeLast, price0CumulativeLast);
         assertEq(pairInfo.price1CumulativeLast, price1CumulativeLast);
 
         // price(0|1)Average = (0 * t0 + token(0|1)Balance * t1) / period
-        assertEq(pairInfo.price0Average._x, 0); 
+        assertEq(pairInfo.price0Average._x, 0);
         assertEq(pairInfo.price1Average._x, 0);
     }
-    
+
     /**
     Test retrieving token(fnft) price in ETH.
      */
@@ -196,7 +196,7 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         // Get Price of FNFT in ETH.
         uint fNFTAmount = 50 ether;
         uint ethPrice = priceOracle.getfNFTPriceETH(fnft, fNFTAmount);
-        
+
         // VERIFY
         assertEq(ethPrice, fNFTAmount * weth.balanceOf(pairAddress)/IERC20Upgradeable(fnft).balanceOf(pairAddress));
     }
@@ -204,7 +204,7 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
     /**
     Test failure in retrieving token(fnft) price in ETH when not enough updates to pair's twap.
      */
-    function testFail_fNFTPriceETH_notEnoughUpdates() public {
+    function testFNFTPriceETHNotEnoughUpdates() public {
         // ACTION
         // Add pair info to price oracle.
         address pairAddress = address(pairWithWeth.uPair());
@@ -224,34 +224,18 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
             priceOracle.updatePairInfo(fnft, wethToken);
         }
 
+        vm.expectRevert(PriceOracle.NotEnoughUpdates.selector);
         // Get Price of FNFT in ETH.
         priceOracle.getfNFTPriceETH(fnft, 50 ether);
     }
-    
+
     /**
     Test failure in retrieving token(fnft) price in ETH when twap does not exist.
      */
-    function testFail_fNFTPriceETH_pairInfoDoesNotExist() public {
-        // ACTION
-        // Add pair info to price oracle.
-        address pairAddress = address(pairWithWeth.uPair());
-        address fnft = address(pairWithWeth.token());
-        address wethToken = address(weth);
+    function testFNFTPriceETHPairInfoDoesNotExist() public {
         address fakeToken = address(new MockERC20Upgradeable());
-        priceOracle.updatePairInfo(fnft, wethToken);
-        IUniswapV2Pair(pairAddress).sync();
-        (, , uint256 blockTimeStampLast) = IUniswapV2Pair(pairAddress).getReserves();
 
-        // Move block.timestamp forward and sync uniswap pair and update price oracle.
-        // Update price oracle pair less than required pair info update.
-        uint jump = priceOracle.period();
-        for (uint i = 0; i <= priceOracle.minimumPairInfoUpdate(); i++) {
-            blockTimeStampLast += jump;
-            vm.warp(blockTimeStampLast);
-            IUniswapV2Pair(pairAddress).sync();
-            priceOracle.updatePairInfo(fnft, wethToken);
-        }
-
+        vm.expectRevert(PriceOracle.PairInfoDoesNotExist.selector);
         // Get Price of fakeToken in ETH.
         priceOracle.getfNFTPriceETH(fakeToken, 50 ether);
     }


### PR DESCRIPTION
@0xluckyg want to see what you think before I make any changes en masse but according to foundry using `testFail` is an anti-pattern because we wouldn't know why a transaction failed.

https://book.getfoundry.sh/forge/cheatcodes.html?highlight=testFail#cheatcodes

![Screenshot 2022-05-12 at 3 58 39 PM](https://user-images.githubusercontent.com/80737357/168105600-fce8ce3c-4d9a-4938-ab5f-3b4418702939.png)

