### PR TITLE
fix: set period and min pair info update events wrong args

### DIFF
--- a/src/contracts/PriceOracle.sol
+++ b/src/contracts/PriceOracle.sol
@@ -26,7 +26,7 @@ contract PriceOracle is OwnableUpgradeable, IPriceOracle {
     address public immutable FACTORY;
 
     /**
-        EVENTS 
+        EVENTS
      */
     event UpdatePeriod(uint256 _old, uint256 _new);
     event UpdateMinimumPairInfoUpdate(uint256 _old, uint256 _new);
@@ -47,21 +47,21 @@ contract PriceOracle is OwnableUpgradeable, IPriceOracle {
 
     function initialize() external initializer {
         __Ownable_init();
-        
+
         period = 10 minutes;
         minimumPairInfoUpdate = 10;
     }
 
     // Set minimum period to wait for the next pair info update.
     function setPeriod(uint256 _newPeriod) external onlyOwner {
-        period = _newPeriod;
         emit UpdatePeriod(period, _newPeriod);
-    } 
+        period = _newPeriod;
+    }
 
     // Set minimum pair info info update required to get fNFT-WETH TWAP price.
     function setMinimumPairInfoUpdate(uint256 _newMinimumPairInfoUpdate) external onlyOwner {
-        minimumPairInfoUpdate = _newMinimumPairInfoUpdate;
         emit UpdateMinimumPairInfoUpdate(minimumPairInfoUpdate, _newMinimumPairInfoUpdate);
+        minimumPairInfoUpdate = _newMinimumPairInfoUpdate;
     }
 
     // Get pair address from factory. Returns address(0) if not found.
@@ -80,7 +80,7 @@ contract PriceOracle is OwnableUpgradeable, IPriceOracle {
         pairInfo = _getTwap[_pair];
     }
 
-    // Update pair info. 
+    // Update pair info.
     function updatePairInfo(address _token0, address _token1) external {
         _updatePairInfo(_token0, _token1);
     }
@@ -123,7 +123,7 @@ contract PriceOracle is OwnableUpgradeable, IPriceOracle {
         }
     }
 
-    // Update pair info of two token pair. 
+    // Update pair info of two token pair.
     function _updatePairInfo(address _token0, address _token1) internal {
         // Get predetermined pair address.
         address pairAddress = _getPairAddress(_token0, _token1);

--- a/src/test/PriceOracle.t.sol
+++ b/src/test/PriceOracle.t.sol
@@ -239,4 +239,34 @@ contract PriceOracleTest is DSTest, SetupEnvironment {
         // Get Price of fakeToken in ETH.
         priceOracle.getfNFTPriceETH(fakeToken, 50 ether);
     }
+
+    event UpdatePeriod(uint256 _old, uint256 _new);
+
+    function testSetPeriod() public {
+        vm.expectEmit(true, false, false, true);
+        emit UpdatePeriod(10 minutes, 20 minutes);
+        priceOracle.setPeriod(20 minutes);
+        assertEq(priceOracle.period(), 20 minutes);
+    }
+
+    function testSetPeriodNotOwner() public {
+        vm.prank(address(1));
+        vm.expectRevert("Ownable: caller is not the owner");
+        priceOracle.setPeriod(20 minutes);
+    }
+
+    event UpdateMinimumPairInfoUpdate(uint256 _old, uint256 _new);
+
+    function testSetMinimumPairInfoUpdate() public {
+        vm.expectEmit(true, false, false, true);
+        emit UpdateMinimumPairInfoUpdate(10, 20);
+        priceOracle.setMinimumPairInfoUpdate(20);
+        assertEq(priceOracle.minimumPairInfoUpdate(), 20);
+    }
+
+    function testSetMinimumPairInfoUpdateNotOwner() public {
+        vm.prank(address(1));
+        vm.expectRevert("Ownable: caller is not the owner");
+        priceOracle.setMinimumPairInfoUpdate(20);
+    }
 }


### PR DESCRIPTION
Previously it was just emitting events with `old` and `new` having the same value because the emission happened after the storage change