### PR TITLE
perf: _getAuctionPrice gas optimization

### DIFF
--- a/src/contracts/FNFT.sol
+++ b/src/contracts/FNFT.sol
@@ -399,20 +399,24 @@ contract FNFT is ERC20Upgradeable, ERC721HolderUpgradeable {
 
             bool aboveLiquidityThreshold = reserve1 * 2 > IFNFTSettings(settings).liquidityThreshold();
 
-            if (!aboveLiquidityThreshold && aboveQuorum){
-                //average reserve
-                return _reservePrice;
-            } else if (aboveLiquidityThreshold && !aboveQuorum) {
-                //twap price if twap > initial reserve
-                //reserve price if twap < initial reserve
-                return twapPrice > initialReserve ? twapPrice : initialReserve;
-            } else if (aboveLiquidityThreshold && aboveQuorum) {
-                //twap price if twap > reserve
-                //reserve price if twap < reserve
-                return twapPrice > _reservePrice ? twapPrice : _reservePrice;
+            if (aboveLiquidityThreshold) {
+                if (aboveQuorum) {
+                    //twap price if twap > reserve
+                    //reserve price if twap < reserve
+                    return twapPrice > _reservePrice ? twapPrice : _reservePrice;
+                } else {
+                    //twap price if twap > initial reserve
+                    //reserve price if twap < initial reserve
+                    return twapPrice > initialReserve ? twapPrice : initialReserve;
+                }
             } else {
-                //initial reserve
-                return initialReserve;
+                if (aboveQuorum) {
+                    //average reserve
+                    return _reservePrice;
+                } else {
+                    //initial reserve
+                    return initialReserve;
+                }
             }
         } else {
             return aboveQuorum ? _reservePrice : initialReserve;


### PR DESCRIPTION
```
testAuctionEndCurator0() (gas: -5 (-0.000%))
testBid() (gas: -5 (-0.000%))
testGetWeth() (gas: -5 (-0.000%))
testGetAuctionPrice_whenVotingAboveQuorumAndLiquidityBelowThreshold_returnUserReservePrice() (gas: -5 (-0.000%))
testGetAuctionPrice_whenVotingBelowQuorumAndLiquidityAboveThreshold_compareTWAPAndInitialReserve() (gas: -48 (-0.000%))
testWithdrawFNFTIfLockedAndRedeemed() (gas: -85 (-0.000%))
testGetAuctionPrice_whenVotingAboveQuorumAndLiquidityAboveThreshold_compareTWAPAndUserReservePrice() (gas: -94 (-0.000%))
testGetAuctionPrice_whenVotingBelowQuorumAndLiquidityBelowThreshold_returnInitialReserve() (gas: -85 (-0.000%))
testBuyItNow() (gas: -11254 (-0.000%))
Overall gas change: -11586 (-0.001%)
```

Not sure if in your opinion this is more or less readable, but there is some gas improvement. Up to you if you think this should be merged.